### PR TITLE
fix: output should not containt console.log

### DIFF
--- a/src/local-provider.mjs
+++ b/src/local-provider.mjs
@@ -86,7 +86,7 @@ export class LocalProvider extends SingleGroupProvider {
       return undefined;
     }
 
-    console.log("REPOSITORY", name);
+    //console.log("REPOSITORY", name);
 
     let repository = this._repositories.get(name);
     if (repository === undefined) {


### PR DESCRIPTION
Hi Markus,
wir benutzen das Modul um mit Branches zu arbeiten. Das utility welches das Modul benutzt wird aufgerufen und soll nur ein String am Ende liefern. Hier kommt dann die console.log Ausgabe zusätzlich hinzu. Wenn du es nicht unbedingt brauchst, würde ich mich freuen wenn du den pull request genehmigst, ansonsten würden wir uns dann anderweitig helfen müssen, Ideen sind vorhanden ))) 
Liebe Grüße
Konstantin